### PR TITLE
Don't report error when user cancels...

### DIFF
--- a/src/main/java/qupath/ext/instanseg/core/InstanSegResults.java
+++ b/src/main/java/qupath/ext/instanseg/core/InstanSegResults.java
@@ -6,11 +6,25 @@ package qupath.ext.instanseg.core;
  * @param nTilesProcessed total number of tiles that were processed, including any that failed
  * @param nTilesFailed number of tiles that threw an exception during processing
  * @param nObjectsDetected number of objects detected in the image
+ * @param processingTimeMillis total time taken to process the image in milliseconds
+ * @param wasInterrupted whether the processing was interrupted; if so, failed tiles are not necessary problematic
  */
 public record InstanSegResults(
         long nPixelsProcessed,
         int nTilesProcessed,
         int nTilesFailed,
         int nObjectsDetected,
-        long processingTimeMillis) {
+        long processingTimeMillis,
+        boolean wasInterrupted) {
+
+    private static final InstanSegResults EMPTY = new InstanSegResults(0, 0, 0, 0, 0, false);
+
+    /**
+     * Get an empty instance of InstanSegResults.
+     * @return
+     */
+    public static InstanSegResults emptyInstance() {
+        return EMPTY;
+    }
+
 }

--- a/src/main/java/qupath/ext/instanseg/ui/InstanSegController.java
+++ b/src/main/java/qupath/ext/instanseg/ui/InstanSegController.java
@@ -821,7 +821,7 @@ public class InstanSegController extends BorderPane {
                     );
             logger.info("Results: {}", results);
             int nFailed = results.nTilesFailed();
-            if (nFailed > 0) {
+            if (nFailed > 0 && !results.wasInterrupted()) {
                 var errorMessage = String.format(resources.getString("error.tiles-failed"), nFailed);
                 logger.error(errorMessage);
                 Dialogs.showErrorMessage(resources.getString("title"), errorMessage);

--- a/src/main/resources/qupath/ext/instanseg/ui/strings.properties
+++ b/src/main/resources/qupath/ext/instanseg/ui/strings.properties
@@ -101,6 +101,6 @@ error.no-imagedata = Cannot run InstanSeg without ImageData.
 error.downloading = Error downloading files
 error.querying-local = Error querying local files
 error.localModel = Can't find file in user model directory
-error.tiles-failed = %d tiles failed. This is often a memory issue.\nConsider decreasing tile size or the number of threads used.
+error.tiles-failed = %d tiles failed. This could be a memory issue.\nConsider decreasing tile size or the number of threads used.
 error.modelPath = Unable to fetch model path
 


### PR DESCRIPTION
...and express less confidence that any errors are memory-related.

Also default `padToInputSize` to `false` again now the bug is fixed.

Additionally, support system properties `instanseg.padToInputSize` and `instanseg.showTiles`. When these are set to `true`, then `padToInputSize` is used and ImageJ windows are opened to show tile inputs and predictions respectively.

These can be useful for debugging.