### PR TITLE
Fix PyTorch downloads when required

### DIFF
--- a/src/main/java/qupath/ext/instanseg/core/PytorchManager.java
+++ b/src/main/java/qupath/ext/instanseg/core/PytorchManager.java
@@ -79,7 +79,7 @@ public class PytorchManager {
         try {
             return callOffline(() -> Engine.getEngine("PyTorch"));
         } catch (Exception e) {
-            logger.info("Failed to fetch offline engine", e);
+            logger.debug("Failed to fetch offline engine", e);
             return null;
         }
     }
@@ -92,7 +92,7 @@ public class PytorchManager {
      * @throws Exception
      */
     private static <T> T callOffline(Callable<T> callable) throws Exception {
-        return callWithTempProperty("offline", "true", callable);
+        return callWithTempProperty("ai.djl.offline", "true", callable);
     }
 
     /**
@@ -103,7 +103,7 @@ public class PytorchManager {
      * @throws Exception
      */
     private static <T> T callOnline(Callable<T> callable) throws Exception {
-        return callWithTempProperty("offline", "false", callable);
+        return callWithTempProperty("ai.djl.offline", "false", callable);
     }
 
 


### PR DESCRIPTION
* Ensure we use the current `ai.djl.offline` property rather than `offline`
* Block the 'Run' button during download to ensure it can't be requested twice before completion
* Try to ensure the device never becomes deselected, and is always updated with what is available