### PR TITLE
System properties for debugging

### DIFF
--- a/src/main/java/qupath/ext/instanseg/core/TilePredictionProcessor.java
+++ b/src/main/java/qupath/ext/instanseg/core/TilePredictionProcessor.java
@@ -143,7 +143,7 @@ class TilePredictionProcessor implements Processor<Mat, Mat, Mat> {
             var matOutput = predictor.predict(mat);
 
             // These are useful for spotting issues with the model
-            if (System.getProperty("instanseg.showTiles", "false").equalsIgnoreCase("true")) {
+            if (System.getProperty("instanseg.debug.predictions", "false").equalsIgnoreCase("true")) {
                 OpenCVTools.matToImagePlus("Input " + params.getRegionRequest(), mat).show();
                 OpenCVTools.matToImagePlus("Output " + params.getRegionRequest(), matOutput).show();
             }

--- a/src/main/java/qupath/ext/instanseg/ui/InstanSegController.java
+++ b/src/main/java/qupath/ext/instanseg/ui/InstanSegController.java
@@ -794,7 +794,6 @@ public class InstanSegController extends BorderPane {
         CompletableFuture.supplyAsync(this::ensurePyTorchAvailable, ForkJoinPool.commonPool())
                         .thenAccept((Boolean success) -> {
                             if (success) {
-                                pendingTask.set(task);
                                 // Reset the pending task when it completes (either successfully or not)
                                 task.stateProperty().addListener((observable, oldValue, newValue) -> {
                                     if (Set.of(Worker.State.CANCELLED, Worker.State.SUCCEEDED, Worker.State.FAILED).contains(newValue)) {
@@ -802,6 +801,9 @@ public class InstanSegController extends BorderPane {
                                             pendingTask.set(null);
                                     }
                                 });
+                                // Setting the pending task prompts it to be run (so we need to do it after attaching
+                                // the listener, in case it ends really quickly)
+                                pendingTask.set(task);
                             }
                         });
     }


### PR DESCRIPTION
I fear it's ugly, but I'm finding it useful at the moment...

The following Groovy script
```
System.properties['instanseg.debug.tiles'] = 'true'
```
can help identify tiles that will be processed, by switching behavior to only show tiles (and not actually calling the prediction).

The purpose is to spot potential redundant calculations that we could remove. For example, in this image some tiles could be cropped - or even dropped entirely, because they only overlap a region that is already covered by at least one other tile.

![image](https://github.com/user-attachments/assets/ef9d45b6-0798-42e4-afb1-b4a1333aef3e)

Before this proposed change, I was hacking about in the code to try to visualize what was happening... 