### PR TITLE
Use TaskRunner for measurements

### DIFF
--- a/src/main/java/qupath/ext/instanseg/core/DetectionMeasurer.java
+++ b/src/main/java/qupath/ext/instanseg/core/DetectionMeasurer.java
@@ -4,8 +4,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import qupath.lib.analysis.features.ObjectMeasurements;
 import qupath.lib.images.ImageData;
+import qupath.lib.images.servers.ImageServer;
 import qupath.lib.images.servers.TransformedServerBuilder;
 import qupath.lib.objects.PathObject;
+import qupath.lib.plugins.PathTask;
+import qupath.lib.plugins.TaskRunner;
+import qupath.lib.plugins.TaskRunnerUtils;
 
 import java.awt.image.BufferedImage;
 import java.io.IOException;
@@ -21,19 +25,23 @@ import java.util.Objects;
  * Note that this is inherently limited to 'small' detections, where the entire ROI can be loaded into memory.
  * It does not support measuring arbitrarily large regions at a high resolution.
  */
-public class DetectionMeasurer {
+class DetectionMeasurer {
 
     private static final Logger logger = LoggerFactory.getLogger(DetectionMeasurer.class);
+
+    private final TaskRunner taskRunner;
 
     private final Collection<ObjectMeasurements.Compartments> compartments;
     private final Collection<ObjectMeasurements.Measurements> measurements;
     private final Collection<ObjectMeasurements.ShapeFeatures> shapeFeatures;
     private final double downsample;
 
-    private DetectionMeasurer(Collection<ObjectMeasurements.Compartments> compartments,
+    private DetectionMeasurer(TaskRunner taskRunner,
+                              Collection<ObjectMeasurements.Compartments> compartments,
                               Collection<ObjectMeasurements.Measurements> measurements,
                               Collection<ObjectMeasurements.ShapeFeatures> shapeFeatures,
                               double downsample) {
+        this.taskRunner = taskRunner;
         this.shapeFeatures = shapeFeatures;
         this.compartments = compartments;
         this.measurements = measurements;
@@ -55,42 +63,84 @@ public class DetectionMeasurer {
      * @param objects The objects to be measured.
      */
     public void makeMeasurements(ImageData<BufferedImage> imageData, Collection<? extends PathObject> objects) {
+        if (objects.isEmpty()) {
+            return;
+        }
+
         var server = imageData.getServer();
         var pixelCal = server.getPixelCalibration();
 
         ObjectMeasurements.ShapeFeatures[] featuresArray = shapeFeatures.toArray(new ObjectMeasurements.ShapeFeatures[0]);
-        objects.parallelStream().forEach(c -> ObjectMeasurements.addShapeMeasurements(c, pixelCal, featuresArray));
 
-        if (!objects.isEmpty()) {
-            logger.info("Making measurements for {} objects", objects.size());
-            var stains = imageData.getColorDeconvolutionStains();
-            var builder = new TransformedServerBuilder(server);
-            if (stains != null) {
-                List<Integer> stainNumbers = new ArrayList<>();
-                for (int s = 1; s <= 3; s++) {
-                    if (!stains.getStain(s).isResidual())
-                        stainNumbers.add(s);
-                }
-                builder.deconvolveStains(stains, stainNumbers.stream().mapToInt(i -> i).toArray());
+        logger.info("Making measurements for {} objects", objects.size());
+        var stains = imageData.getColorDeconvolutionStains();
+        var builder = new TransformedServerBuilder(server);
+        if (stains != null) {
+            List<Integer> stainNumbers = new ArrayList<>();
+            for (int s = 1; s <= 3; s++) {
+                if (!stains.getStain(s).isResidual())
+                    stainNumbers.add(s);
             }
+            builder.deconvolveStains(stains, stainNumbers.stream().mapToInt(i -> i).toArray());
+        }
 
+        try {
+            // Submit all the measurement tasks
+            var server2 = builder.build();
+            List<PathTask> tasks = new ArrayList<>();
+            for (var cell : objects) {
+                tasks.add(new MeasurementTask(server2, cell, downsample, featuresArray, compartments, measurements));
+            }
+            taskRunner.runTasks(tasks);
+            // It's possible we have the same server - in which case we don't want to close it twice
+            if (!Objects.equals(server, server2)) {
+                server2.close();
+            }
+        } catch (Exception e) {
+            logger.error("Exception when creating intensity measurements", e);
+        }
+
+    }
+
+    private static class MeasurementTask implements PathTask {
+
+        private final ImageServer<BufferedImage> server;
+        private final PathObject detection;
+        private final double downsample;
+        private final ObjectMeasurements.ShapeFeatures[] featuresArray;
+        private final Collection<ObjectMeasurements.Compartments> compartments;
+        private final Collection<ObjectMeasurements.Measurements> measurements;
+
+        private String lastError;
+
+        private MeasurementTask(ImageServer<BufferedImage> server, PathObject detection, double downsample,
+                                ObjectMeasurements.ShapeFeatures[] featuresArray, Collection<ObjectMeasurements.Compartments> compartments,
+                                Collection<ObjectMeasurements.Measurements> measurements) {
+            this.server = server;
+            this.detection = detection;
+            this.downsample = downsample;
+            // No defensive copy needed only because this is private
+            this.featuresArray = featuresArray;
+            this.compartments = compartments;
+            this.measurements = measurements;
+        }
+
+        @Override
+        public String getLastResultsDescription() {
+            return lastError == null ? "Measured " + detection : "Completed with error: " + lastError;
+        }
+
+        @Override
+        public void run() {
             try {
-                var server2 = builder.build();
-                objects.parallelStream().forEach(cell -> {
-                    try {
-                        ObjectMeasurements.addIntensityMeasurements(server2, cell, downsample, measurements, compartments);
-                    } catch (IOException e) {
-                        logger.info(e.getLocalizedMessage(), e);
-                    }
-                });
-                // It's possible we have the same server - in which case we don't want to close it twice
-                if (!Objects.equals(server, server2)) {
-                    server2.close();
+                if (featuresArray.length > 0) {
+                    ObjectMeasurements.addShapeMeasurements(detection, server.getPixelCalibration(), featuresArray);
                 }
-            } catch (Exception e) {
-                logger.error("Exception when creating intensity measurements", e);
+                ObjectMeasurements.addIntensityMeasurements(server, detection, downsample, measurements, compartments);
+            } catch (IOException e) {
+                lastError = e.getLocalizedMessage();
+                logger.error("Exception adding measurements: {}", e.getMessage(), e);
             }
-
         }
     }
 
@@ -100,12 +150,23 @@ public class DetectionMeasurer {
      */
     public static class Builder {
 
+        private TaskRunner taskRunner;
         private Collection<ObjectMeasurements.Compartments> compartments = Arrays.asList(ObjectMeasurements.Compartments.values());
         private Collection<ObjectMeasurements.Measurements> measurements = Arrays.stream(ObjectMeasurements.Measurements.values())
                 .filter(m -> m != ObjectMeasurements.Measurements.VARIANCE) // Skip variance - we have standard deviation
                 .toList();
         private Collection<ObjectMeasurements.ShapeFeatures> shapeFeatures = Arrays.asList(ObjectMeasurements.ShapeFeatures.values());
         private double downsample;
+
+        /**
+         * Specify the task runner used to run parallel tasks.
+         * @param taskRunner
+         * @return
+         */
+        public Builder taskRunner(TaskRunner taskRunner) {
+            this.taskRunner = taskRunner;
+            return this;
+        }
 
         /**
          * Set the downsample that the measurer should use.
@@ -156,7 +217,8 @@ public class DetectionMeasurer {
          * @return An immutable detection measurer.
          */
         public DetectionMeasurer build() {
-            return new DetectionMeasurer(compartments, measurements, shapeFeatures, downsample);
+            var runner = taskRunner == null ? TaskRunnerUtils.getDefaultInstance().createTaskRunner() : taskRunner;
+            return new DetectionMeasurer(runner, compartments, measurements, shapeFeatures, downsample);
         }
     }
 }

--- a/src/main/java/qupath/ext/instanseg/core/DetectionMeasurer.java
+++ b/src/main/java/qupath/ext/instanseg/core/DetectionMeasurer.java
@@ -148,7 +148,7 @@ class DetectionMeasurer {
     /**
      * A builder class for DetectionMeasurer.
      */
-    public static class Builder {
+    static class Builder {
 
         private TaskRunner taskRunner;
         private Collection<ObjectMeasurements.Compartments> compartments = Arrays.asList(ObjectMeasurements.Compartments.values());

--- a/src/main/java/qupath/ext/instanseg/core/InstanSeg.java
+++ b/src/main/java/qupath/ext/instanseg/core/InstanSeg.java
@@ -114,9 +114,8 @@ public class InstanSeg {
         validateImageAndObjectsOrThrow(imageData, pathObjects);
         var results = runInstanSeg(imageData, pathObjects);
         if (makeMeasurements) {
-            for (var pathObject : pathObjects) {
-                makeMeasurements(imageData, pathObject.getChildObjects());
-            }
+            var detections = pathObjects.stream().flatMap(p -> p.getChildObjects().stream()).toList();
+            makeMeasurements(imageData, detections);
         }
         return results;
     }
@@ -148,6 +147,7 @@ public class InstanSeg {
     private void makeMeasurements(ImageData<BufferedImage> imageData, Collection<? extends PathObject> detections) {
         double downsample = model.getPreferredDownsample(imageData.getServer().getPixelCalibration());
         DetectionMeasurer.builder()
+                .taskRunner(taskRunner)
                 .downsample(downsample)
                 .build()
                 .makeMeasurements(imageData, detections);


### PR DESCRIPTION
This has two advantages:
* It blocks the UI when measuring objects
    * Fixes #89 
* It shows a progress bar if measurements are taking a while

In making this change, I also made `DetectionMeasurer` private - since public access isn't currently required.