### PR TITLE
Use QP approach to selecting cores and add selection to history

### DIFF
--- a/src/main/java/qupath/ext/instanseg/ui/InstanSegController.java
+++ b/src/main/java/qupath/ext/instanseg/ui/InstanSegController.java
@@ -44,6 +44,8 @@ import qupath.lib.gui.QuPathGUI;
 import qupath.lib.gui.tools.GuiTools;
 import qupath.lib.gui.tools.WebViews;
 import qupath.lib.images.ImageData;
+import qupath.lib.objects.PathObjectTools;
+import qupath.lib.plugins.workflow.DefaultScriptableWorkflowStep;
 
 import java.awt.image.BufferedImage;
 import java.beans.PropertyChangeEvent;
@@ -838,17 +840,16 @@ public class InstanSegController extends BorderPane {
     private void selectAllAnnotations() {
         var hierarchy = qupath.getImageData().getHierarchy();
         hierarchy.getSelectionModel().setSelectedObjects(hierarchy.getAnnotationObjects(), null);
+        var step = new DefaultScriptableWorkflowStep("Select all annotations", "selectAnnotations()");
+        qupath.imageDataProperty().get().getHistoryWorkflow().addStep(step);
     }
 
     @FXML
     private void selectAllTMACores() {
         var hierarchy = qupath.getImageData().getHierarchy();
-        hierarchy.getSelectionModel().setSelectedObjects(
-                hierarchy
-                        .getTMAGrid().getTMACoreList()
-                        .stream().filter(core -> !core.isMissing())
-                        .toList(),
-                null);
+        hierarchy.getSelectionModel().setSelectedObjects(PathObjectTools.getTMACoreObjects(hierarchy, false),null);
+        var step = new DefaultScriptableWorkflowStep("Select all TMA cores", "selectTMACores()");
+        qupath.imageDataProperty().get().getHistoryWorkflow().addStep(step);
     }
 
     private void promptToUpdateDirectory(StringProperty dirPath) {


### PR DESCRIPTION
Improve handling of missing and null grids, and add the selection of annotations/TMA cores to the workflow history