### PR TITLE
Model versioning and display

### DIFF
--- a/src/main/java/qupath/ext/instanseg/core/InstanSegModel.java
+++ b/src/main/java/qupath/ext/instanseg/core/InstanSegModel.java
@@ -48,8 +48,8 @@ public class InstanSegModel {
     }
 
     private InstanSegModel(String name, URL modelURL) {
-        this.modelURL = modelURL;
         this.name = name;
+        this.modelURL = modelURL;
     }
 
     /**
@@ -215,8 +215,9 @@ public class InstanSegModel {
         String name = getName();
         String parent = getPath().map(Path::getFileName).map(Path::toString).orElse(null);
         String version = getModel().map(BioimageIoSpec.BioimageIoModel::getVersion).orElse(null);
-        if (parent != null && !Objects.equals(parent, name))
+        if (parent != null && !parent.equals(name)) {
             name = parent + "/" + name;
+        }
         if (version != null)
             name += "-" + version;
         return name;

--- a/src/main/java/qupath/ext/instanseg/core/InstanSegModel.java
+++ b/src/main/java/qupath/ext/instanseg/core/InstanSegModel.java
@@ -245,7 +245,6 @@ public class InstanSegModel {
         return name;
     }
 
-
     /**
      * Try to check the number of channels in the model.
      * @return The integer if the model is downloaded, otherwise empty
@@ -264,7 +263,6 @@ public class InstanSegModel {
         }
     }
 
-
     /**
      * Retrieve the BioImage model spec.
      * @return The BioImageIO model spec for this InstanSeg model.
@@ -272,7 +270,6 @@ public class InstanSegModel {
     private Optional<BioimageIoSpec.BioimageIoModel> getModel() {
         return Optional.ofNullable(model);
     }
-
 
     private static Path downloadZipIfNeeded(URL url, Path localDirectory, String filename) throws IOException {
         var zipFile = localDirectory.resolve(Path.of(filename + ".zip"));
@@ -341,8 +338,6 @@ public class InstanSegModel {
         bos.close();
     }
 
-
-
     private String getREADMEString(Path path) {
         var file = path.resolve(name + "_README.md");
         if (Files.exists(file)) {
@@ -387,6 +382,5 @@ public class InstanSegModel {
             return (int)Math.round(output.getShape().getOffset()[ind] * 2);
         });
     }
-
 
 }

--- a/src/main/java/qupath/ext/instanseg/ui/InstanSegController.java
+++ b/src/main/java/qupath/ext/instanseg/ui/InstanSegController.java
@@ -282,7 +282,6 @@ public class InstanSegController extends BorderPane {
 
     /**
      * Open the model directory in the system file browser when double-clicked.
-     * @param event
      */
     @FXML
     void handleModelDirectoryLabelClick(MouseEvent event) {
@@ -357,22 +356,28 @@ public class InstanSegController extends BorderPane {
             // Return if we could store previously-saved checks - this will fail if the items have changed,
             // of if there were no previous checks (e.g. because its'a new model)
             return;
-        } else if (imageData.isBrightfield()) {
-            comboInputChannels.getCheckModel().checkIndices(IntStream.range(0, 3).toArray());
-            var modelDir = InstanSegUtils.getModelDirectory().orElse(null);
-            if (model != null && modelDir != null && model.isDownloaded(modelDir)) {
-                var modelChannels = model.getNumChannels();
-                if (modelChannels.isPresent()) {
-                    int nModelChannels = modelChannels.get();
-                    if (nModelChannels != InstanSegModel.ANY_CHANNELS) {
-                        comboInputChannels.getCheckModel().clearChecks();
-                        comboInputChannels.getCheckModel().checkIndices(0, 1, 2);
-                    }
-                }
+        }
 
-            }
-        } else {
+        if (!imageData.isBrightfield()) {
+            // if fluorescence or similar, then bung in all channels
             comboInputChannels.getCheckModel().checkIndices(IntStream.range(0, imageData.getServer().nChannels()).toArray());
+            return;
+        }
+
+        // if brightfield, then check R, G, and B
+        comboInputChannels.getCheckModel().checkIndices(IntStream.range(0, 3).toArray());
+        var modelDir = InstanSegUtils.getModelDirectory().orElse(null);
+        // todo: not clear why this is needed. is this handling the checkcombobox weirdness on clearing checks, or?
+        if (model != null && modelDir != null && model.isDownloaded(modelDir)) {
+            var modelChannels = model.getNumChannels();
+            if (modelChannels.isPresent()) {
+                int nModelChannels = modelChannels.get();
+                if (nModelChannels != InstanSegModel.ANY_CHANNELS) {
+                    comboInputChannels.getCheckModel().clearChecks();
+                    comboInputChannels.getCheckModel().checkIndices(0, 1, 2);
+                }
+            }
+
         }
     }
 

--- a/src/main/java/qupath/ext/instanseg/ui/ModelListCell.java
+++ b/src/main/java/qupath/ext/instanseg/ui/ModelListCell.java
@@ -30,7 +30,7 @@ public class ModelListCell extends ListCell<InstanSegModel> {
             setGraphic(null);
             setTooltip(null);
         } else {
-            setText(model.getName());
+            setText(model.toString());
             var dir = InstanSegUtils.getLocalModelDirectory().orElse(null);
             if (dir != null && !model.isDownloaded(dir)) {
                 setGraphic(web);
@@ -38,7 +38,7 @@ public class ModelListCell extends ListCell<InstanSegModel> {
                 setTooltip(tooltip);
             } else {
                 setGraphic(null);
-                tooltip.setText(model.getName());
+                tooltip.setText(model.toString());
                 setTooltip(tooltip);
             }
         }

--- a/src/main/java/qupath/ext/instanseg/ui/Watcher.java
+++ b/src/main/java/qupath/ext/instanseg/ui/Watcher.java
@@ -146,15 +146,15 @@ class Watcher {
                     // because this is read from rdf.yaml.
                     // To reduce the risk of this causing trouble, do a full directory refresh on any change.
                     if (kind == ENTRY_CREATE) {
-                        logger.info("File created: {}", rawEvent);
+                        logger.debug("File created: {}", rawEvent);
                         refreshAllModelPaths();
                     }
                     if (kind == ENTRY_DELETE) {
-                        logger.info("File deleted: {}", rawEvent);
+                        logger.debug("File deleted: {}", rawEvent);
                         refreshAllModelPaths();
                     }
                     if (kind == ENTRY_MODIFY) {
-                        logger.info("File modified: {}", rawEvent);
+                        logger.debug("File modified: {}", rawEvent);
                         refreshAllModelPaths();
                     }
                 }


### PR DESCRIPTION
This makes the model directory display in the dropdown menu if it's not the same as the model name, along with the version if present. Previously directory and version were only shown if the model was selected.

Also reduces the log level for some Watcher events