### PR TITLE
Enable MPS on Mac always

### DIFF
--- a/src/main/java/qupath/ext/instanseg/core/PytorchManager.java
+++ b/src/main/java/qupath/ext/instanseg/core/PytorchManager.java
@@ -50,7 +50,7 @@ public class PytorchManager {
                 availableDevices.add(name);
             }
             // If we could use MPS, but don't have it already, add it
-            if (GeneralTools.isMac() && "aarch64".equals(System.getProperty("os.arch"))) {
+            if (GeneralTools.isMac()) {
                 availableDevices.add("mps");
             }
             // CPU should always be available


### PR DESCRIPTION
Seems it isn't limited to usefulness on Apple Silicon.

See https://github.com/qupath/qupath-extension-instanseg/issues/118

We can't verify this, but it does improve things substantially when running the Intel build on Apple Silicon (still required for CZI files, for example) - so is beneficial anyway.