### PR TITLE
Fix output selection using named argument

### DIFF
--- a/src/main/java/qupath/ext/instanseg/core/MatTranslator.java
+++ b/src/main/java/qupath/ext/instanseg/core/MatTranslator.java
@@ -60,13 +60,14 @@ class MatTranslator implements Translator<Mat, Mat[]> {
         var manager = ctx.getNDManager();
         var ndarray = DjlTools.matToNDArray(manager, input, inputLayoutNd);
         var out = new NDList(ndarray);
+        List<NDArray> args = sanitizeOptionalArgs(optionalArgs, manager);
+        out.addAll(args);
         if (outputChannels != null) {
             var array = manager.create(outputChannels);
+            array.setName("args.target_segmentation");
             var arrayCPU = array.toDevice(Device.cpu(), false);
             out.add(arrayCPU);
         }
-        List<NDArray> args = sanitizeOptionalArgs(optionalArgs, manager);
-        out.addAll(args);
         return out;
     }
 


### PR DESCRIPTION
Untested (working on managed desktop atm...) attempt to fix output selection

I tried just changing the order of adding things to the output `NDList` but this had no effect. My (highly tentative) reasoning here is that the first unnamed argument is passed first, followed by unnamed arguments. However I realise it could also be that if I switch the order and then set `array.setName("target_segmentation");` then the output selection will be passed first. This would be preferred.