### PR TITLE
Improve channel selection on model download

### DIFF
--- a/src/main/java/qupath/ext/instanseg/ui/CheckModelCache.java
+++ b/src/main/java/qupath/ext/instanseg/ui/CheckModelCache.java
@@ -71,7 +71,7 @@ public class CheckModelCache<S, T> {
      */
     public boolean restoreChecks() {
         List<Integer> checks = lastChecks.get(value.get());
-        if (checks != null && checks.stream().allMatch(i -> i < checkbox.getItems().size())) {
+        if (checks != null && !checks.isEmpty() && checks.stream().allMatch(i -> i < checkbox.getItems().size())) {
             var checkModel = checkbox.getCheckModel();
             checkModel.clearChecks();
             checks.forEach(checkModel::checkIndices);


### PR DESCRIPTION
Attempt to make a better selection of input and output channels when a model is first downloaded.

Before downloading, it's not known exactly what channels are available or required - and currently the channels may be valid when the user clicks 'Run', but then become reset to something invalid once the model arrives.

I don't think this convoluted code handles things perfectly, but I think it is an improvement... at least from my explorations, after repeatedly deleting models and redownloading across a few images.