### PR TITLE
Add default behaviour to output type selection

### DIFF
--- a/src/main/java/qupath/ext/instanseg/core/InstanSeg.java
+++ b/src/main/java/qupath/ext/instanseg/core/InstanSeg.java
@@ -672,6 +672,16 @@ public class InstanSeg {
         }
 
         /**
+         * Output whatever the default object type for the model is: probably cells for nuclei + cell models, nuclei for everything else.
+         * @return this builder
+         */
+        private Builder outputDefault() {
+            this.preferredOutputType = null;
+            return this;
+        }
+
+
+        /**
          * Set the output type based on a string value.
          * @param outputType the type of output (usually cell, annotation or detection)
          * @return this builder.
@@ -687,10 +697,12 @@ public class InstanSeg {
                 case ANNOTATION -> {
                     return this.outputAnnotations();
                 }
+                case DEFAULT -> {
+                    return this.outputDefault();
+                }
                 default -> throw new IllegalArgumentException("Unknown output type");
             }
         }
-
 
         /**
          * Set a number of optional arguments
@@ -747,7 +759,11 @@ public class InstanSeg {
         /**
          * Output possibly cells that may or may not have a nucleus
          */
-        CELL;
+        CELL,
+        /**
+         * Whatever the default model behaviour is.
+         */
+        DEFAULT;
 
         /**
          * Fetch the output type matching a string value.

--- a/src/main/java/qupath/ext/instanseg/ui/InstanSegController.java
+++ b/src/main/java/qupath/ext/instanseg/ui/InstanSegController.java
@@ -212,7 +212,7 @@ public class InstanSegController extends BorderPane {
     }
 
     private void configureOutputTypeCombo() {
-        comboOutputType.getItems().addAll("Annotations", "Detections", "Cells");
+        comboOutputType.getItems().addAll("Default", "Detections", "Annotations", "Cells");
         comboOutputType.getSelectionModel().select(0);
     }
 


### PR DESCRIPTION
Add an extra `Default` option to the "Output type" combo box that restores the original behavior, and which most people should leave turned on: detections most of the time, but cells for 2-channel output. It remains possible to specify annotations, detections or cells specifically.