### PR TITLE
Only restore checks when the number of available items matches

### DIFF
--- a/src/main/java/qupath/ext/instanseg/ui/CheckModelCache.java
+++ b/src/main/java/qupath/ext/instanseg/ui/CheckModelCache.java
@@ -55,13 +55,15 @@ public class CheckModelCache<S, T> {
 
     private List<Boolean> checksToBoolean(CheckComboBox<T> checkbox) {
         List<Boolean> out = new ArrayList<>(Collections.nCopies(checkbox.getItems().size(), false));
-        checkbox.getCheckModel().getCheckedIndices().forEach(i -> out.set(i, true));
+        if (!out.isEmpty()) {
+            checkbox.getCheckModel().getCheckedIndices().forEach(i -> out.set(i, true));
+        }
         return out;
     }
 
-    private void checkFromBoolean(CheckComboBox<T> checkbox, List<Boolean> checks) {
-        for (int i = 0; i < checks.size(); i++) {
-            if (checks.get(i)) {
+    private void checkFromBoolean(CheckComboBox<T> checkbox, List<Boolean> isChecked) {
+        for (int i = 0; i < isChecked.size(); i++) {
+            if (isChecked.get(i)) {
                 checkbox.getCheckModel().check(i);
             }
         }

--- a/src/main/java/qupath/ext/instanseg/ui/CheckModelCache.java
+++ b/src/main/java/qupath/ext/instanseg/ui/CheckModelCache.java
@@ -1,6 +1,7 @@
 package qupath.ext.instanseg.ui;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyObjectProperty;
@@ -54,7 +55,7 @@ public class CheckModelCache<S, T> {
 
     private List<Boolean> checksToBoolean(CheckComboBox<T> checkbox) {
         List<Boolean> out = new ArrayList<>(Collections.nCopies(checkbox.getItems().size(), false));
-        checkbox.getCheckModel().getCheckedIndices().forEach(i -> out.set(i, false));
+        checkbox.getCheckModel().getCheckedIndices().forEach(i -> out.set(i, true));
         return out;
     }
 

--- a/src/main/java/qupath/ext/instanseg/ui/InstanSegController.java
+++ b/src/main/java/qupath/ext/instanseg/ui/InstanSegController.java
@@ -403,15 +403,23 @@ public class InstanSegController extends BorderPane {
             return;
         }
 
+        var modelDir = InstanSegUtils.getModelDirectory().orElse(null);
         if (!imageData.isBrightfield()) {
-            // if fluorescence or similar, then bung in all channels
+            // if not a brightfield image but brightfield model, then don't check anything
+            if (model != null && modelDir != null && model.isValid()) {
+                int nModelChannels = model.getNumChannels().orElse(InstanSegModel.ANY_CHANNELS);
+                if (nModelChannels != InstanSegModel.ANY_CHANNELS) {
+                    comboInputChannels.getCheckModel().clearChecks();
+                    return;
+                }
+            }
+            // if fluorescence image and arbitrary channel model, then bung in all channels
             comboInputChannels.getCheckModel().checkIndices(IntStream.range(0, imageData.getServer().nChannels()).toArray());
             return;
         }
 
         // if brightfield, then check R, G, and B
         comboInputChannels.getCheckModel().checkIndices(IntStream.range(0, 3).toArray());
-        var modelDir = InstanSegUtils.getModelDirectory().orElse(null);
         if (model != null && modelDir != null && model.isValid()) {
             var modelChannels = model.getNumChannels();
             if (modelChannels.isPresent()) {

--- a/src/main/java/qupath/ext/instanseg/ui/InstanSegController.java
+++ b/src/main/java/qupath/ext/instanseg/ui/InstanSegController.java
@@ -399,7 +399,7 @@ public class InstanSegController extends BorderPane {
         var model = selectedModel.get();
         if (model != null && inputChannelCache.restoreChecks() && !comboInputChannels.getCheckModel().isEmpty()) {
             // Return if we could store previously-saved checks - this will fail if the items have changed,
-            // of if there were no previous checks (e.g. because its'a new model)
+            // of if there were no previous checks (e.g. because it's a new model)
             return;
         }
 

--- a/src/main/java/qupath/ext/instanseg/ui/InstanSegController.java
+++ b/src/main/java/qupath/ext/instanseg/ui/InstanSegController.java
@@ -407,14 +407,15 @@ public class InstanSegController extends BorderPane {
 
     /**
      * Reset the checked input channels based on the current image and a model.
+     * If the number of channels in the image file matches the number in the model,
+     * or if we have an arbitrary channel model, then check all channels.
+     * Otherwise, check none.
      * @param imageData the current image, used to query number of channels available
      * @param model a model, used to check how many channels we handle
      */
     private void resetInputChecks(ImageData<BufferedImage> imageData, InstanSegModel model) {
         if (model != null && model.isValid()) {
             int nModelChannels = model.getNumChannels().orElse(InstanSegModel.ANY_CHANNELS);
-            // if the number of channels in the image file matches the number in the model, or if we have an arbitrary channel model check all
-            // otherwise, check none
             comboInputChannels.getCheckModel().clearChecks();
             if (nModelChannels == imageData.getServer().nChannels() || nModelChannels == InstanSegModel.ANY_CHANNELS) {
                 comboInputChannels.getCheckModel().checkIndices(IntStream.range(0, imageData.getServer().nChannels()).toArray());

--- a/src/main/java/qupath/ext/instanseg/ui/InstanSegController.java
+++ b/src/main/java/qupath/ext/instanseg/ui/InstanSegController.java
@@ -1,6 +1,7 @@
 package qupath.ext.instanseg.ui;
 
 import com.google.gson.Gson;
+import java.util.Arrays;
 import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
@@ -381,7 +382,6 @@ public class InstanSegController extends BorderPane {
         }
     }
 
-
     private void updateInputChannels(ImageData<BufferedImage> imageData) {
         if (imageData == null) {
             return;
@@ -392,8 +392,10 @@ public class InstanSegController extends BorderPane {
         }
         // Store the checks without changing the current value
         inputChannelCache.snapshotChecks();
-        // Update the items
-        comboInputChannels.getCheckModel().clearChecks();
+        // Update the items, if some are available to be checked
+        if (!comboInputChannels.getItems().isEmpty()) {
+            comboInputChannels.getCheckModel().clearChecks();
+        }
         comboInputChannels.getItems().clear();
         comboInputChannels.getItems().setAll(InputChannelItem.getAvailableChannels(imageData));
         var model = selectedModel.get();
@@ -539,8 +541,8 @@ public class InstanSegController extends BorderPane {
         // Try to restore last used channels - but need to ensure this is valid for the model
         var inputChannelsRestored = inputChannelCache.restoreChecks() && (numChannels == InstanSegModel.ANY_CHANNELS
                 || numChannels == comboInputChannels.getCheckModel().getItemCount());
-        // If we couldn't restore the channels, set as many as we need to be checked
-        if (!inputChannelsRestored) {
+        // If we couldn't restore the channels, set as many as we need to be checked, assuming there are items to be checked
+        if (!inputChannelsRestored && comboInputChannels.getCheckModel().getItemCount() > 0) {
             resetInputChecks(qupath.getImageData(), model);
         }
         // Handle output channels


### PR DESCRIPTION
Currently, the CheckModelCache restores the previously-set checks assuming that the number of available checks is less than or equal to the maximum checked index.

The aim of this PR is to avoid restoring checks when the number of available currently checks is different to the number of previously available checks.

This means that switching from a 2 channel to a 5 channel image will result in all channels being checked, as the CheckModelCache will now refuse to restore checks given the mismatch in the number of available items. Previously, the checks from the 2 channel image would be applied to the first two channels of the 5 channel image.

Resolve #147 or close as wontfix