### PR TITLE
Update model dir label if changed & valid

### DIFF
--- a/src/main/java/qupath/ext/instanseg/ui/InstanSegController.java
+++ b/src/main/java/qupath/ext/instanseg/ui/InstanSegController.java
@@ -774,12 +774,13 @@ public class InstanSegController extends BorderPane {
     }
 
     private void configureDirectoryLabel() {
-        isModelDirectoryValid.addListener((v, o, n) -> updateModelDirectoryLabel());
-        updateModelDirectoryLabel();
+        isModelDirectoryValid.addListener((v, o, n) -> updateModelDirectoryLabel(n));
+        modelDirectoryBinding.addListener((v, o, n) -> updateModelDirectoryLabel(isModelDirectoryValid.get()));
+        updateModelDirectoryLabel(isModelDirectoryValid.get());
     }
 
-    private void updateModelDirectoryLabel() {
-        if (isModelDirectoryValid.get()) {
+    private void updateModelDirectoryLabel(Boolean b) {
+        if (b) {
             modelDirLabel.getStyleClass().setAll("standard-message");
             String modelPath = modelDirectoryBinding.get().toString();
             modelDirLabel.setText(modelPath);


### PR DESCRIPTION
Previously, the model directory label would only update when changing from invalid to valid.

To reproduce:

1. open instanseg
2. set the model dir to any valid directory
3. observe the updated label
4. change the model directory to any other valid dir
5. observe the label has not updated (although internally the directory property has changed)

Expected behaviour:

The model dir label should reflect the internal property.