### PR TITLE
Add a default model dir in the same vein as the default user dir

### DIFF
--- a/src/main/resources/qupath/ext/instanseg/ui/strings.properties
+++ b/src/main/resources/qupath/ext/instanseg/ui/strings.properties
@@ -72,6 +72,14 @@ ui.options.nChannelSelected = %d channels selected
 ui.options.directory = Downloaded model directory
 ui.options.directory-name = Models:
 ui.options.directory-not-set.tooltip = Choose a directory where models should be stored
+ui.options.directory-exists = %s already exists.\n\
+  Do you want to use this default, or specify another directory?
+ui.options.directory-create = Do you want to create a new model directory at \n%s?
+ui.options.directory-cannot-create = Unable to create directory at \n%s
+ui.options.directory-default = Use default
+ui.options.directory-choose = Choose directory
+ui.options.directory-choose-model = Choose model directory
+ui.options.cancel = Cancel
 ui.options.directory-not-set = Choose directory to store models
 ui.options.directory.tooltip = Double-click the model directory name to open it in the system browser
 


### PR DESCRIPTION
Currently, the extension does not suggest any default for the user's model directory. This is a bit annoying and causes friction when most users will just want the extension to store models "somewhere". Therefore provide a default within the user directory, where user data is stored by default for other aspects of QuPath. Resolve #174